### PR TITLE
Use version of debug which comes with `dist`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   "version": "0.9.1",
   "dependencies": {
     "polymer": "Polymer/polymer#^1.4.0",
-    "visionmedia-debug": "^2.2.0"
+    "visionmedia-debug": "2.4.4"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   "version": "0.9.1",
   "dependencies": {
     "polymer": "Polymer/polymer#^1.4.0",
-    "visionmedia-debug": "2.4.4"
+    "visionmedia-debug": "2.2.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",


### PR DESCRIPTION
versions of `debug` after 2.4.4 no longer come with a `dist` folder, which `log-behavior` relies on.